### PR TITLE
Adds privateRoot fix for reports page.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -58,9 +58,9 @@ function App() {
             <PublicRoute path="/login" restricted>
               <LoginPage />
             </PublicRoute>
-            <PublicRoute path="/reports">
+            <PrivateRoute path="/reports">
               <ReportsPage />
-            </PublicRoute>
+            </PrivateRoute>
             <PublicRoute path="/google-redirect">
               <GoogleRedirectPage />
             </PublicRoute>

--- a/src/components/PrivateRoute/PrivateRoute.jsx
+++ b/src/components/PrivateRoute/PrivateRoute.jsx
@@ -4,11 +4,11 @@ import { Route, Redirect } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { authSelectors } from '../../redux/auth';
 
-export default function PrivateRoute({ children, exact, path }) {
-  const isLoggedIn = useSelector(authSelectors.getIsLoggedIn);
+export default function PrivateRoute({ children, exact = false, path }) {
+  const hasToken = useSelector(authSelectors.getUserToken);
   return (
     <Route exact={exact} path={path}>
-      {isLoggedIn ? children : <Redirect to="/login" />}
+      {hasToken ? children : <Redirect exact to="/login" />}
     </Route>
   );
 }

--- a/src/components/ToReports/ToReports.jsx
+++ b/src/components/ToReports/ToReports.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
+import { NavLink } from 'react-router-dom';
 import { ReactComponent as BarChartIcon } from '../../assets/bar-chart.svg';
 import styles from './ToReports.module.scss';
 
 function ToReports() {
   return (
-    <div className={styles.container}>
+    <NavLink to="/reports" className={styles.container}>
       <p className={styles.text}>Перейти к отчётам</p>
       <BarChartIcon className={styles.icon} />
-    </div>
+    </NavLink>
   );
 }
 

--- a/src/components/ToReports/ToReports.module.scss
+++ b/src/components/ToReports/ToReports.module.scss
@@ -7,6 +7,7 @@
   padding: 5px 5px 5px 0;
   align-items: flex-end;
   width: fit-content;
+  text-decoration: none;
   color: $dark-grey-color;
   fill: $dark-grey-color;
   &:hover,

--- a/src/redux/auth/auth-selectors.js
+++ b/src/redux/auth/auth-selectors.js
@@ -8,12 +8,15 @@ const getIsFetchingCurrentUser = state => state.auth.isFetchingCurrentUser;
 
 const getUserBalance = state => state.auth.balance;
 
+const getUserToken = state => state.auth.token;
+
 const authSelectors = {
   getIsLoggedIn,
   getUserName,
   getIsRegistered,
   getIsFetchingCurrentUser,
   getUserBalance,
+  getUserToken,
 };
 
 export default authSelectors;


### PR DESCRIPTION
 Привіт, Олю! 
Здається пофіксила, методом гугла щось нагуглила.
Дивна поведінка, бо в багатьох прикладах в неті та наших записах цей підхід працював для всіх приватних маршрутів.
Що я змінила - умова доступу до private page тепер не в isLoggedIn а в hasToken, тобто по наявності токена. Є підозра що на момент виклику приватного маршруту, ще немає доступу до auth об'єкту в redux, а так як токен в нас з local storage, він є. В мене так на локал хості працює :)
Додала ще NavLink до компоненту ToReports щоб можна було переходити.
